### PR TITLE
Stick down some versions so it builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ err-ctx = "0.2"
 fern = "0.5"
 hyper = "0.12"
 hyper-tls = "0.3"
-log = "0.4"
+log = "^0.4.8"
 log-panics = "2"
 ndarray = "0.12"
 serde_json = "1"
@@ -25,10 +25,11 @@ tokio = "0.1"
 websocket = "0.22"
 
 [dependencies.cursive]
-version = "0.12.1-alpha.0"
+version = "0.13.0"
 default-features = false
 features = ["crossterm-backend"]
 git = "https://github.com/gyscos/Cursive.git"
+tag = "v0.13.0"
 
 [dependencies.old_futures]
 package = "futures"
@@ -39,5 +40,6 @@ version = "0.3.0-alpha"
 features = ["compat"]
 
 [dependencies.screeps-api]
-version = "0.5"
+version = "0.6"
 git = "https://github.com/daboross/rust-screeps-api.git"
+tag = "screeps-api-0.6.0"


### PR DESCRIPTION
This is not really "fixing" it entirely since there are still mysterious build failures on rustc 1.44-nightly 2020-04-09, only with `cargo install --path .`, but *not* with `cargo build`. Regardless, this PR causes it to *sometimes* build.

```
dev/srv - [fix-build●] » cargo install --path .
  Installing srv v0.1.0 (/home/lf/dev/srv)
    Updating crates.io index
    Updating git repository `https://github.com/gyscos/Cursive.git`
    Updating git repository `https://github.com/daboross/rust-screeps-api.git`
   Compiling srv v0.1.0 (/home/lf/dev/srv)
warning: unused imports: `cell::RefCell`, `rc::Rc`
 --> src/ui/console.rs:1:11
  |
1 | use std::{cell::RefCell, mem, rc::Rc};
  |           ^^^^^^^^^^^^^       ^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `CbSink`, `ColorStyle`, `Direction`, `EventResult`, `Event`, `Key`, `MouseButton`, `MouseEvent`, `Orientation`, `Printer`, `Vec2`, `XY`, `menu::MenuTr
ee`
  --> src/ui/console.rs:4:17
   |
4  |     direction::{Direction, Orientation},
   |                 ^^^^^^^^^  ^^^^^^^^^^^
5  |     event::{Event, EventResult, Key, MouseButton, MouseEvent},
   |             ^^^^^  ^^^^^^^^^^^  ^^^  ^^^^^^^^^^^  ^^^^^^^^^^
6  |     menu::MenuTree,
   |     ^^^^^^^^^^^^^^
7  |     theme::{BaseColor, Color, ColorStyle},
   |                               ^^^^^^^^^^
...
11 |     CbSink, Cursive, Printer, Vec2, XY,
   |     ^^^^^^           ^^^^^^^  ^^^^  ^^

error[E0220]: associated type `SinkError` not found for `futures_sink::Sink<websocket::message::OwnedMessage>`
   --> src/net.rs:252:28
    |
252 |     Si: Sink<OwnedMessage, SinkError = Error> + Unpin,
    |                            ^^^^^^^^^ associated type `SinkError` not found

error: aborting due to previous error

For more information about this error, try `rustc --explain E0220`.
error: failed to compile `srv v0.1.0 (/home/lf/dev/srv)`, intermediate artifacts can be found at `/home/lf/dev/srv/target`

Caused by:
  could not compile `srv`.

To learn more, run the command again with --verbose.
```